### PR TITLE
Allow critic gradients in advantage computation

### DIFF
--- a/bots.py
+++ b/bots.py
@@ -110,10 +110,11 @@ class RLAgent:
         values_t = torch.stack(values)
         log_probs_t = torch.stack(log_probs)
         entropies_t = torch.stack(entropies)
-        advantages = returns_t - values_t.detach()
-        advantages = (advantages - advantages.mean()) / (advantages.std() + 1e-8)
-        policy_loss = -(log_probs_t * advantages).mean()
-        value_loss = advantages.pow(2).mean()
+        advantages = returns_t - values_t
+        policy_adv = advantages.detach()
+        policy_adv = (policy_adv - policy_adv.mean()) / (policy_adv.std() + 1e-8)
+        policy_loss = -(log_probs_t * policy_adv).mean()
+        value_loss = (returns_t - values_t).pow(2).mean()
         entropy_loss = entropies_t.mean()
         loss = policy_loss + 0.5 * value_loss - 0.01 * entropy_loss
         self.optimizer.zero_grad()


### PR DESCRIPTION
## Summary
- Recompute advantages using undetached value estimates
- Detach advantages only for policy loss and normalize this copy
- Compute critic loss from squared return-value error

## Testing
- `python -m py_compile bots.py`
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_6892509e849c8325981bbf9d4b2817c7