### PR TITLE
Train three GPU-ready agents against fixed seat

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,3 @@
+*.pth
+__pycache__/
+*.pyc

--- a/README.md
+++ b/README.md
@@ -1,1 +1,30 @@
-# 1234
+# Six Nimmt! RL
+
+This repository implements a reinforcement learning setup for the card game *6 nimmt!*.
+
+## Files
+- `six_nimmt_env.py` – Gymnasium environment of the game.
+- `bots.py` – helper agents (`RandomBot`, `RuleBot`, and `RLAgent`).
+- `train_six_nimmt.py` – self-play training of three actor-critic agents against a fixed opponent with optional GPU acceleration and text rendering of sample games.
+- `play_six_nimmt.py` – console interface to play as player 0 against the trained agents.
+
+## Usage
+Run extended self-play training (will overwrite previous models):
+
+```bash
+python train_six_nimmt.py --cycles 30 --episodes 1200 --batch-size 8 --num-envs 256 --device cuda
+```
+
+`--batch-size` controls how many *batches* of parallel episodes contribute to
+each optimisation step. Combine it with `--num-envs` to roll out many games in
+lockstep and feed massive tensors to the GPU.
+
+Use `--load` to skip training and reuse existing `agent*_best.pth`. After training the script evaluates the three learners against the baseline, stores their average penalties in `agent_scores.json`, and renders three sample games in text form.
+
+To challenge the trained policies interactively, run:
+
+```bash
+python play_six_nimmt.py --device cuda
+```
+
+The script loads the three trained models; missing weights fall back to the heuristic `RuleBot`.

--- a/bots.py
+++ b/bots.py
@@ -1,0 +1,170 @@
+import random
+from typing import List, Tuple
+
+import numpy as np
+import torch
+import torch.nn as nn
+import torch.optim as optim
+
+
+class RandomBot:
+    def act(self, obs: np.ndarray) -> int:
+        hand = [c for c in obs[:10] if c > 0]
+        idxs = [i for i, c in enumerate(obs[:10]) if c > 0]
+        return random.choice(idxs)
+
+
+class RuleBot:
+    def act(self, obs: np.ndarray) -> int:
+        hand = [c for c in obs[:10] if c > 0]
+        row_tops = obs[10:14]
+        best_idx = None
+        best_diff = 105
+        for i, card in enumerate(hand):
+            diffs = [card - top for top in row_tops if card > top]
+            if diffs:
+                d = min(diffs)
+                if d < best_diff:
+                    best_diff = d
+                    best_idx = i
+        if best_idx is None:
+            # no card fits, play smallest
+            return int(np.argmin(obs[:10]))
+        # need to convert best_idx from hand order to position in obs
+        card_value = hand[best_idx]
+        for i, c in enumerate(obs[:10]):
+            if c == card_value:
+                return i
+        return 0
+
+
+class PolicyNet(nn.Module):
+    def __init__(self, obs_dim: int, hidden: int = 512, n_actions: int = 10):
+        super().__init__()
+        self.net = nn.Sequential(
+            nn.Linear(obs_dim, hidden),
+            nn.ReLU(),
+            nn.Linear(hidden, n_actions),
+        )
+
+    def forward(self, x: torch.Tensor) -> torch.Tensor:
+        return self.net(x)
+
+
+class ValueNet(nn.Module):
+    def __init__(self, obs_dim: int, hidden: int = 512):
+        super().__init__()
+        self.net = nn.Sequential(
+            nn.Linear(obs_dim, hidden),
+            nn.ReLU(),
+            nn.Linear(hidden, 1),
+        )
+
+    def forward(self, x: torch.Tensor) -> torch.Tensor:
+        return self.net(x).squeeze(-1)
+
+
+class RLAgent:
+    """Simple actor-critic agent."""
+
+    def __init__(self, obs_dim: int, lr: float = 3e-4, device: str | None = None):
+        self.device = torch.device(device or ("cuda" if torch.cuda.is_available() else "cpu"))
+        self.policy = PolicyNet(obs_dim).to(self.device)
+        self.value = ValueNet(obs_dim).to(self.device)
+        params = list(self.policy.parameters()) + list(self.value.parameters())
+        self.optimizer = optim.Adam(params, lr=lr)
+
+    def act(self, obs: np.ndarray) -> Tuple[int, torch.Tensor, torch.Tensor, torch.Tensor]:
+        """Select an action for a single observation."""
+        acts, logp, ent, val = self.act_batch(obs[None, :])
+        return int(acts[0]), logp[0], ent[0], val[0]
+
+    def act_batch(
+        self, obs_batch: np.ndarray
+    ) -> Tuple[np.ndarray, torch.Tensor, torch.Tensor, torch.Tensor]:
+        """Vectorised action selection for a batch of observations."""
+        obs_t = torch.as_tensor(obs_batch, dtype=torch.float32, device=self.device)
+        logits = self.policy(obs_t)
+        mask = obs_t[:, :10].gt(0).float()
+        masked = logits - (1 - mask) * 1e9
+        dist = torch.distributions.Categorical(logits=masked)
+        actions = dist.sample()
+        logp = dist.log_prob(actions)
+        ent = dist.entropy()
+        values = self.value(obs_t)
+        return actions.cpu().numpy(), logp, ent, values
+
+    def update(
+        self,
+        log_probs: List[torch.Tensor],
+        values: List[torch.Tensor],
+        rewards: List[float],
+        entropies: List[torch.Tensor],
+        gamma: float = 0.99,
+    ) -> None:
+        """Update policy and value networks from episode logs."""
+        returns: List[float] = []
+        G = 0.0
+        for r in reversed(rewards):
+            G = r + gamma * G
+            returns.insert(0, G)
+        returns_t = torch.tensor(returns, dtype=torch.float32, device=self.device)
+        values_t = torch.stack(values).to(self.device)
+        log_probs_t = torch.stack(log_probs).to(self.device)
+        entropies_t = torch.stack(entropies).to(self.device)
+        advantages = returns_t - values_t
+        policy_adv = advantages.detach()
+        policy_adv = (policy_adv - policy_adv.mean()) / (policy_adv.std() + 1e-8)
+        policy_loss = -(log_probs_t * policy_adv).mean()
+        value_loss = (returns_t - values_t).pow(2).mean()
+        entropy_loss = entropies_t.mean()
+        loss = policy_loss + 0.5 * value_loss - 0.01 * entropy_loss
+        self.optimizer.zero_grad()
+        loss.backward()
+        self.optimizer.step()
+
+    def update_batch(
+        self,
+        log_probs: torch.Tensor,
+        values: torch.Tensor,
+        rewards: torch.Tensor,
+        entropies: torch.Tensor,
+        gamma: float = 0.99,
+    ) -> None:
+        """Update from batched trajectories.
+
+        All tensors are expected to have shape ``(batch, steps)`` where batch
+        is the number of parallel episodes."""
+        returns = torch.zeros_like(rewards)
+        G = torch.zeros(rewards.size(0), device=self.device)
+        for t in reversed(range(rewards.size(1))):
+            G = rewards[:, t] + gamma * G
+            returns[:, t] = G
+        log_probs_t = log_probs.reshape(-1)
+        values_t = values.reshape(-1)
+        returns_t = returns.reshape(-1)
+        entropies_t = entropies.reshape(-1)
+        advantages = returns_t - values_t
+        policy_adv = advantages.detach()
+        policy_adv = (policy_adv - policy_adv.mean()) / (policy_adv.std() + 1e-8)
+        policy_loss = -(log_probs_t * policy_adv).mean()
+        value_loss = (returns_t - values_t).pow(2).mean()
+        entropy_loss = entropies_t.mean()
+        loss = policy_loss + 0.5 * value_loss - 0.01 * entropy_loss
+        self.optimizer.zero_grad()
+        loss.backward()
+        self.optimizer.step()
+
+    # Utility methods for persistence
+    def save(self, path: str) -> None:
+        torch.save({
+            "policy": self.policy.state_dict(),
+            "value": self.value.state_dict(),
+        }, path)
+
+    def load(self, path: str) -> None:
+        state = torch.load(path, map_location=self.device)
+        self.policy.load_state_dict(state["policy"])
+        self.value.load_state_dict(state["value"])
+        self.policy.to(self.device).eval()
+        self.value.to(self.device).eval()

--- a/play_six_nimmt.py
+++ b/play_six_nimmt.py
@@ -1,0 +1,83 @@
+import os
+from typing import List
+
+import torch
+
+from six_nimmt_env import SixNimmtEnv, bull_value
+from bots import RLAgent, RuleBot
+
+
+def load_opponents(env: SixNimmtEnv, device: str) -> List:
+    opponents: List = []
+    for i in range(1, 4):
+        path = f"agent{i}_best.pth"
+        if os.path.exists(path):
+            agent = RLAgent(env.obs_dim, device=device)
+            agent.load(path)
+            opponents.append(agent)
+        else:
+            opponents.append(RuleBot())
+    return opponents
+
+
+def print_board(env: SixNimmtEnv) -> None:
+    print("\n" + "=" * 50)
+    for idx, row in enumerate(env.rows):
+        penalty = sum(bull_value(c) for c in row)
+        cards = " ".join(f"{c:02d}" for c in row)
+        print(f"Row {idx + 1}: {cards:<25} | penalty {penalty:2d}")
+    score_line = " ".join(f"P{i}:{s}" for i, s in enumerate(env.scores))
+    print(f"Scores -> {score_line}")
+    print("=" * 50)
+
+
+def choose_card(hand: List[int]) -> int:
+    valid = [c for c in hand if c > 0]
+    mapping = [i for i, c in enumerate(hand) if c > 0]
+    while True:
+        choices = "  ".join(f"[{j}] {valid[j]}" for j in range(len(valid)))
+        print(f"Your hand: {choices}")
+        raw = input("Select card index: ")
+        if raw.isdigit():
+            idx = int(raw)
+            if 0 <= idx < len(mapping):
+                return mapping[idx]
+        print("Invalid choice, try again.")
+
+
+def main(device: str = "cpu") -> None:
+    env = SixNimmtEnv()
+    opponents = load_opponents(env, device)
+    obs, _ = env.reset()
+    done = False
+    while not done:
+        print_board(env)
+        action = choose_card(list(obs[0, :10]))
+        actions = [action]
+        for i, bot in enumerate(opponents, start=1):
+            if isinstance(bot, RLAgent):
+                act, _, _, _ = bot.act(obs[i])
+            else:
+                act = bot.act(obs[i])
+            actions.append(act)
+        obs, rewards, done, _, _ = env.step(actions)
+    print_board(env)
+    print("Game over!")
+    for i, score in enumerate(env.scores):
+        tag = "(You)" if i == 0 else ""
+        print(f"Player {i} {tag}: {score} penalty")
+    winner = min(range(4), key=lambda i: env.scores[i])
+    if winner == 0:
+        print("You win!")
+    else:
+        print(f"Player {winner} wins.")
+
+
+if __name__ == "__main__":
+    import argparse
+
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--device", type=str, default="cuda" if torch.cuda.is_available() else "cpu")
+    args = parser.parse_args()
+
+    main(device=args.device)

--- a/six_nimmt_env.py
+++ b/six_nimmt_env.py
@@ -1,0 +1,128 @@
+import random
+from typing import List, Tuple
+import numpy as np
+import gymnasium as gym
+from gymnasium import spaces
+
+np.seterr(over='ignore')
+
+
+def bull_value(card: int) -> int:
+    """Return penalty (bull heads) for a card."""
+    if card == 55:
+        return 7
+    if card % 11 == 0:
+        return 5
+    if card % 10 == 0:
+        return 3
+    if card % 5 == 0:
+        return 2
+    return 1
+
+
+class SixNimmtEnv(gym.Env):
+    """Multi-agent environment for 6 nimmt!.
+
+    The environment operates with four players simultaneously. Observations and
+    actions are arrays with shape (n_players, ...). Each action is an index of a
+    card in player's hand (0-9). Invalid indices are mapped to the smallest
+    available card.
+    """
+
+    metadata = {"render_modes": ["human"]}
+
+    def __init__(self, n_players: int = 4):
+        super().__init__()
+        self.n_players = n_players
+        self.action_space = spaces.MultiDiscrete([10] * n_players)
+        # Observation: 10 cards + 4 row tops + 4 row lengths
+        self.obs_dim = 18
+        low = np.zeros((n_players, self.obs_dim), dtype=np.int32)
+        high = np.full((n_players, self.obs_dim), 104, dtype=np.int32)
+        self.observation_space = spaces.Box(low, high, dtype=np.int32)
+        self.rows: List[List[int]] = []
+        self.hands: List[List[int]] = []
+        self.scores: List[int] = []
+        self.current_step: int = 0
+
+    # ------------------------------------------------------------------ utils
+    def _deal(self) -> None:
+        deck = list(range(1, 105))
+        random.shuffle(deck)
+        self.rows = [[deck.pop()] for _ in range(4)]
+        self.hands = [sorted(deck[i * 10:(i + 1) * 10]) for i in range(self.n_players)]
+        self.scores = [0 for _ in range(self.n_players)]
+        self.current_step = 0
+
+    def _row_penalty(self, row: List[int]) -> int:
+        return sum(bull_value(c) for c in row)
+
+    def _get_obs(self) -> np.ndarray:
+        obs = np.zeros((self.n_players, self.obs_dim), dtype=np.int32)
+        row_tops = [r[-1] for r in self.rows]
+        row_lens = [len(r) for r in self.rows]
+        for p in range(self.n_players):
+            hand = self.hands[p]
+            padded = hand + [0] * (10 - len(hand))
+            obs[p, :10] = padded
+            obs[p, 10:14] = row_tops
+            obs[p, 14:18] = row_lens
+        return obs
+
+    def reset(self, seed: int | None = None, options: dict | None = None):
+        super().reset(seed=seed)
+        if seed is not None:
+            random.seed(seed)
+            np.random.seed(seed)
+        self._deal()
+        return self._get_obs(), {}
+
+    # ------------------------------------------------------------------ step
+    def step(self, actions: List[int]):
+        assert len(actions) == self.n_players
+        # Retrieve selected cards; replace invalid indices with smallest card
+        plays: List[Tuple[int, int]] = []  # (player, card)
+        for p, act in enumerate(actions):
+            hand = self.hands[p]
+            valid = [c for c in hand if c > 0]
+            if not valid:
+                # should not happen, but guard
+                card = 0
+            else:
+                idx = act
+                if idx >= len(hand) or hand[idx] == 0:
+                    # map to smallest available card
+                    idx = next(i for i, c in enumerate(hand) if c > 0)
+                card = hand.pop(idx)
+            plays.append((p, card))
+        # resolve plays in ascending order of card
+        plays.sort(key=lambda x: x[1])
+        rewards = [0 for _ in range(self.n_players)]
+        for p, card in plays:
+            # choose row
+            diffs = [(card - row[-1] if card > row[-1] else 105) for row in self.rows]
+            min_diff = min(diffs)
+            if min_diff == 105:  # card smaller than all row tops
+                # take row with least penalty
+                row_idx = min(range(4), key=lambda i: self._row_penalty(self.rows[i]))
+                rewards[p] -= self._row_penalty(self.rows[row_idx])
+                self.rows[row_idx] = [card]
+                self.scores[p] += -rewards[p]
+                continue
+            row_idx = diffs.index(min_diff)
+            if len(self.rows[row_idx]) >= 5:
+                # take row
+                rewards[p] -= self._row_penalty(self.rows[row_idx])
+                self.rows[row_idx] = [card]
+                self.scores[p] += -rewards[p]
+            else:
+                self.rows[row_idx].append(card)
+        self.current_step += 1
+        terminated = self.current_step >= 10
+        return self._get_obs(), rewards, terminated, False, {}
+
+    # ---------------------------------------------------------------- render
+    def render(self):
+        row_str = " | ".join(f"{i}:{row}" for i, row in enumerate(self.rows))
+        score_str = ", ".join(f"P{i}:{s}" for i, s in enumerate(self.scores))
+        print(f"Rows: {row_str}\nScores: {score_str}\n")

--- a/train_six_nimmt.py
+++ b/train_six_nimmt.py
@@ -1,0 +1,209 @@
+import os
+import json
+import random
+from typing import List, Sequence
+
+import numpy as np
+import torch
+
+from six_nimmt_env import SixNimmtEnv
+from bots import RLAgent, RuleBot
+
+
+# ---------------------------------------------------------------------------
+# Training and evaluation utilities
+
+def run_episode(env: SixNimmtEnv, players: Sequence, collect_logs: bool = True):
+    obs, _ = env.reset()
+    log_probs = [[] for _ in players]
+    entropies = [[] for _ in players]
+    values = [[] for _ in players]
+    rewards = [[] for _ in players]
+    done = False
+    while not done:
+        actions = []
+        for i, p in enumerate(players):
+            if isinstance(p, RLAgent):
+                act, logp, ent, val = p.act(obs[i])
+                actions.append(act)
+                if collect_logs:
+                    log_probs[i].append(logp)
+                    entropies[i].append(ent)
+                    values[i].append(val)
+            else:
+                actions.append(p.act(obs[i]))
+        obs, step_rewards, done, _, _ = env.step(actions)
+        for i in range(len(players)):
+            rewards[i].append(step_rewards[i])
+    return log_probs, values, rewards, entropies, env.scores
+
+
+def run_batch(envs: List[SixNimmtEnv], players: Sequence):
+    """Run one episode concurrently in each environment.
+
+    ``players`` may contain fixed bots; logs are collected only for RL agents."""
+
+    num_envs = len(envs)
+    n_players = len(players)
+    obs = np.stack([env.reset()[0] for env in envs])
+    logs = [
+        {"log_probs": [], "values": [], "rewards": [], "entropies": []}
+        if isinstance(p, RLAgent)
+        else None
+        for p in players
+    ]
+    rl_device = next((p.device for p in players if isinstance(p, RLAgent)), "cpu")
+    for _ in range(10):
+        actions = np.zeros((num_envs, n_players), dtype=int)
+        for i, p in enumerate(players):
+            if isinstance(p, RLAgent):
+                acts, logp, ent, val = p.act_batch(obs[:, i, :])
+                actions[:, i] = acts
+                logs[i]["log_probs"].append(logp)
+                logs[i]["entropies"].append(ent)
+                logs[i]["values"].append(val)
+            else:
+                acts = np.array([p.act(obs[e, i, :]) for e in range(num_envs)], dtype=int)
+                actions[:, i] = acts
+        step_rew = torch.zeros(num_envs, n_players, device=rl_device)
+        for e, env in enumerate(envs):
+            obs_e, rew, _, _, _ = env.step(actions[e].tolist())
+            obs[e] = obs_e
+            step_rew[e] = torch.tensor(rew, device=rl_device)
+        for i, p in enumerate(players):
+            if isinstance(p, RLAgent):
+                logs[i]["rewards"].append(step_rew[:, i])
+    out = []
+    for i, p in enumerate(players):
+        if isinstance(p, RLAgent):
+            logp = torch.stack(logs[i]["log_probs"], dim=1)
+            vals = torch.stack(logs[i]["values"], dim=1)
+            rews = torch.stack(logs[i]["rewards"], dim=1)
+            ents = torch.stack(logs[i]["entropies"], dim=1)
+            out.append((logp, vals, rews, ents))
+        else:
+            out.append(None)
+    return out
+
+
+def evaluate_agents(env: SixNimmtEnv, agents: Sequence, games: int = 150):
+    total = np.zeros(len(agents))
+    for _ in range(games):
+        _, _, _, _, scores = run_episode(env, agents, collect_logs=False)
+        total += np.array(scores)
+    return total / games
+
+
+def train_selfplay(
+    cycles: int = 30,
+    episodes_per_cycle: int = 1200,
+    batch_size: int = 8,
+    device: str | None = None,
+    num_envs: int = 1,
+) -> tuple[List, List[float]]:
+    """Train three learning agents against a fixed opponent."""
+
+    envs = [SixNimmtEnv(n_players=4) for _ in range(num_envs)]
+    eval_env = SixNimmtEnv(n_players=4)
+    base_lr = 3e-4
+    lrs = [base_lr * (1 + 0.1 * i) for i in range(3)]
+    agents: List = [RuleBot()] + [RLAgent(eval_env.obs_dim, lr=lr, device=device) for lr in lrs]
+    best_scores = [float("inf")] * len(agents)
+    for cycle in range(cycles):
+        batch_logs = [
+            {"log_probs": [], "values": [], "rewards": [], "entropies": []}
+            if isinstance(p, RLAgent)
+            else None
+            for p in agents
+        ]
+        batches = int(np.ceil(episodes_per_cycle / num_envs))
+        for b in range(batches):
+            logs = run_batch(envs, agents)
+            for i, p in enumerate(agents):
+                if isinstance(p, RLAgent):
+                    logp, val, rew, ent = logs[i]
+                    batch_logs[i]["log_probs"].append(logp)
+                    batch_logs[i]["values"].append(val)
+                    batch_logs[i]["rewards"].append(rew)
+                    batch_logs[i]["entropies"].append(ent)
+            if (b + 1) % batch_size == 0:
+                for i, p in enumerate(agents):
+                    if isinstance(p, RLAgent) and batch_logs[i]["log_probs"]:
+                        log_probs = torch.cat(batch_logs[i]["log_probs"], dim=0)
+                        values = torch.cat(batch_logs[i]["values"], dim=0)
+                        rewards = torch.cat(batch_logs[i]["rewards"], dim=0)
+                        entropies = torch.cat(batch_logs[i]["entropies"], dim=0)
+                        p.update_batch(log_probs, values, rewards, entropies)
+                        batch_logs[i] = {"log_probs": [], "values": [], "rewards": [], "entropies": []}
+        for i, p in enumerate(agents):
+            if isinstance(p, RLAgent) and batch_logs[i]["log_probs"]:
+                log_probs = torch.cat(batch_logs[i]["log_probs"], dim=0)
+                values = torch.cat(batch_logs[i]["values"], dim=0)
+                rewards = torch.cat(batch_logs[i]["rewards"], dim=0)
+                entropies = torch.cat(batch_logs[i]["entropies"], dim=0)
+                p.update_batch(log_probs, values, rewards, entropies)
+        avg = evaluate_agents(eval_env, agents, games=200)
+        for i, p in enumerate(agents):
+            if isinstance(p, RLAgent) and avg[i] < best_scores[i]:
+                best_scores[i] = avg[i]
+                p.save(f"agent{i}_best.pth")
+        print(f"Cycle {cycle}: avg penalties {avg}")
+    return agents, best_scores
+
+
+def render_games(env: SixNimmtEnv, agents: Sequence, n: int = 3):
+    for g in range(n):
+        print(f"=== Game {g+1} ===")
+        obs, _ = env.reset()
+        done = False
+        while not done:
+            actions = []
+            for i, ag in enumerate(agents):
+                if isinstance(ag, RLAgent):
+                    act, _, _, _ = ag.act(obs[i])
+                else:
+                    act = ag.act(obs[i])
+                actions.append(act)
+            obs, _, done, _, _ = env.step(actions)
+            env.render()
+
+
+if __name__ == "__main__":
+    import argparse
+
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--load", action="store_true", help="skip training and load saved agents")
+    parser.add_argument("--cycles", type=int, default=30)
+    parser.add_argument("--episodes", type=int, default=1200)
+    parser.add_argument("--batch-size", type=int, default=8)
+    parser.add_argument("--device", type=str, default="cuda" if torch.cuda.is_available() else "cpu")
+    parser.add_argument("--num-envs", type=int, default=1, help="number of parallel environments")
+    args = parser.parse_args()
+
+    env = SixNimmtEnv(n_players=4)
+    if args.load:
+        agents = [RuleBot()] + [RLAgent(env.obs_dim, device=args.device) for _ in range(env.n_players - 1)]
+        for i in range(1, env.n_players):
+            agents[i].load(f"agent{i}_best.pth")
+        if os.path.exists("agent_scores.json"):
+            with open("agent_scores.json", "r") as f:
+                best_scores = json.load(f)
+        else:
+            best_scores = evaluate_agents(env, agents, games=300).tolist()
+            with open("agent_scores.json", "w") as f:
+                json.dump(best_scores, f)
+    else:
+        agents, best_scores = train_selfplay(
+            args.cycles,
+            args.episodes,
+            args.batch_size,
+            device=args.device,
+            num_envs=args.num_envs,
+        )
+        with open("agent_scores.json", "w") as f:
+            json.dump(best_scores, f)
+
+    rl_scores = best_scores[1:]
+    best_idx = int(np.argmin(rl_scores)) + 1
+    print(f"Best agent: {best_idx} with avg penalty {best_scores[best_idx]:.2f}")
+    render_games(env, agents, n=3)


### PR DESCRIPTION
## Summary
- allow mixed player types in batched rollouts and self-play, keeping logs only for learning agents
- train three actor-critic opponents while a fixed rule-based seat stands in for the future human player
- streamline console interface and documentation to load those three models and pit them against a human at seat 0

## Testing
- `python train_six_nimmt.py --cycles 1 --episodes 5 --batch-size 2 --device cpu --num-envs 1`
- `python play_six_nimmt.py <<'EOF'
0
0
0
0
0
0
0
0
0
0
EOF`

------
https://chatgpt.com/codex/tasks/task_e_68922f27af688325aa701a570f73a9aa